### PR TITLE
Remove unnecessary space character

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -4,7 +4,7 @@ const chalk = require('chalk');
 
 let init = function (size) {
     switch (size) {
-        case  'little':
+        case 'little':
             littleSize();
             break;
         case 'big':


### PR DESCRIPTION
Remove an extra space character between the `case` keyword and a value.