### PR TITLE
Fix inconsistency in functions definition

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -2,7 +2,7 @@
 
 const chalk = require('chalk');
 
-let init = function (size) {
+function init(size) {
     switch (size) {
         case  'little':
             littleSize();
@@ -14,7 +14,7 @@ let init = function (size) {
             middleSize();
             break;
     }
-};
+}
 
 function littleSize() {
     console.info(`


### PR DESCRIPTION
Fix inconsistency in definition of functions in the `lib/index.js` module. This commits makes the definition style of `init` match one used in `littleSize`, `middleSize` and `bigSize`.

An alternative commit which makes them all unnamed is also offered, please cherry-pick either you consider following your code style onto master (or just merge one of these branches if you don't care about merge commits in your history).